### PR TITLE
chore: Update capsize dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "postpublish": "pinst --enable"
   },
   "dependencies": {
-    "@capsizecss/metrics": "^0.4.0",
-    "@capsizecss/unpack": "^0.2.0",
+    "@capsizecss/metrics": "^1.0.1",
+    "@capsizecss/unpack": "^1.0.0",
     "magic-regexp": "^0.6.0",
     "magic-string": "^0.27.0",
     "pathe": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ importers:
 
   .:
     specifiers:
-      '@capsizecss/metrics': ^0.4.0
-      '@capsizecss/unpack': ^0.2.0
+      '@capsizecss/metrics': ^1.0.1
+      '@capsizecss/unpack': ^1.0.0
       '@nuxtjs/eslint-config-typescript': latest
       '@release-it/conventional-changelog': latest
       '@types/node': 18.11.19
@@ -39,8 +39,8 @@ importers:
       vite: 3.2.5
       vitest: 0.28.4
     dependencies:
-      '@capsizecss/metrics': 0.4.0
-      '@capsizecss/unpack': 0.2.1
+      '@capsizecss/metrics': 1.0.1
+      '@capsizecss/unpack': 1.0.0
       magic-regexp: 0.6.0
       magic-string: 0.27.0
       pathe: 1.0.0
@@ -293,12 +293,12 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@capsizecss/metrics/0.4.0:
-    resolution: {integrity: sha512-jPQDSAcJWli5YV2Ab8e4i3IYQLZOMCVoYprbL8rJWLwg9Ct0FNtVxA9LfmWdj+bXYh1r+i8WPHCXZ/RXR0fnyg==}
+  /@capsizecss/metrics/1.0.1:
+    resolution: {integrity: sha512-Ox2n3gSm8X8UciUkKjXUEDfAhEC+xVz+6wQS5GCCxOw2Zc7RGLOMbeuCgtuTarp5eVfjPp3iaqhCfJiP0UWfjA==}
     dev: false
 
-  /@capsizecss/unpack/0.2.1:
-    resolution: {integrity: sha512-JuMIMpgaHyKjTUy6bv+OQgOjaSd6VeOU6XZcO5yQnzbPgrHA57XvnPzSPkokHQELChoSOllFz9RoLmR6sT0qSA==}
+  /@capsizecss/unpack/1.0.0:
+    resolution: {integrity: sha512-cXPI7IWQrPANXKYZwqZf53q2SuYnDkexpi9KzGNWls1NDK26lZqkE1Ry2XuMo9eGkqcmMSgVI8gJbMEgjX7bTQ==}
     dependencies:
       blob-to-buffer: 1.2.9
       cross-fetch: 3.1.5

--- a/src/css.ts
+++ b/src/css.ts
@@ -42,7 +42,14 @@ interface GenerateOptions {
   [key: string]: any
 }
 
-export const generateFontFace = (metrics: Font, options: GenerateOptions) => {
+export type FontFaceMetrics = Pick<
+  Font,
+  'ascent' | 'descent' | 'lineGap' | 'unitsPerEm'
+>
+export const generateFontFace = (
+  metrics: FontFaceMetrics,
+  options: GenerateOptions
+) => {
   const { name, fallbacks, ...properties } = options
 
   // TODO: implement size-adjust: 'width' of web font / 'width' of fallback font

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -48,12 +48,9 @@ describe('getMetricsForFamily', () => {
     expect(metrics).toMatchInlineSnapshot(`
       {
         "ascent": 1968,
-        "capHeight": 1486,
         "descent": -546,
-        "familyName": "Merriweather Sans",
         "lineGap": 0,
         "unitsPerEm": 2000,
-        "xHeight": 1114,
       }
     `)
     // Test cache
@@ -96,12 +93,9 @@ describe('readMetrics', () => {
     expect(metrics).toMatchInlineSnapshot(`
       {
         "ascent": 1050,
-        "capHeight": 698,
         "descent": -350,
-        "familyName": "Poppins",
         "lineGap": 100,
         "unitsPerEm": 1000,
-        "xHeight": 548,
       }
     `)
   })
@@ -117,12 +111,9 @@ describe('readMetrics', () => {
     expect(metrics).toMatchInlineSnapshot(`
       {
         "ascent": 1050,
-        "capHeight": 698,
         "descent": -350,
-        "familyName": "Poppins",
         "lineGap": 100,
         "unitsPerEm": 1000,
-        "xHeight": 548,
       }
     `)
     server.close()


### PR DESCRIPTION
Upgrades both the Capsize `metrics` and `unpack` packages to the latest versions.

Includes a slight internal refactor to decouple from the shape of metrics internally from the `unpack` package. So snapshot tests should be more stable when upgrading.