### PR TITLE
fix: don't override `font-family: inherit`

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -91,7 +91,7 @@ export const FontaineTransform = createUnplugin(
             .map(f => f.trim())
             .filter(f => !f.startsWith('var('))
 
-          if (!families.length) continue
+          if (!families.length || families[0] === 'inherit') continue
 
           s.overwrite(
             index,


### PR DESCRIPTION
### 🔗 Linked issue

Fixes https://github.com/nuxt-modules/fontaine/issues/155

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Overriding `font-family: inherit` to `font-family: inherit, "inherit override"` leads to an invalid property value. This occured when using Nuxt ([reproduction](https://stackblitz.com/edit/github-cltkj9?file=app.vue)) but not without it (inside fontaine/playground).

The fix is implemented by skipping overrides if the first family is 'inherit' because I assume that only the first family is used to determine the fallback font and there is no need for a separate one if inherits the fallback anyway. Another idea was to filter out 'inherit' like you did with 'var(...' but I think that would lead to it being removed from the entire property value, even if it has no effect on the fallback font.

I was only able to test it by editing the code inside node_modules directly. Would be interesting to know how you would approach fixing this :).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.