### PR TITLE
fix: support `moduleResolution: "Bundler"` in TS

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     }


### PR DESCRIPTION
While importing 'fontaine' from an ES module context (either a '.mjs' file or a '.js' file when `type: "module"` is present within the consumer’s package.json file), type declarations for 'node_modules/fontaine/dist/index.mjs' can’t be resolved.

> There are types at 'node_modules/fontaine/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'fontaine' library may need to update its package.json or typings.

By adding a [`"types"` conditional export](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) explicitly, TypeScript projects would be able to resolve the type declarations of fontaine when `moduleResolution: "Bundler"` is specified [within TSConfig](https://www.typescriptlang.org/tsconfig#moduleResolution).